### PR TITLE
Fix readme example code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ proc load() =
     sampleText=newText("Hello World!",getDefaultFont())
 
 proc update(dt: float) =
-    if isKeyPressed(KeyEscape):
+    if isKeyPressed(KeyboardKey.Escape):
         quit()
 
 proc draw() =


### PR DESCRIPTION
The current example code in the README file doesn't compile - it has `isKeyPressed(KeyEscape)` in it, while it appears it should be `isKeyPressed(KeyboardKey.Escape)`.

The version with KeyEscape causes a build error:
`Error: undeclared identifier: 'KeyEscape'`