### PR TITLE
Add JavaScript Bridge for Web Targets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -311,6 +311,12 @@ isResized(): bool  #checks if window has been resized last frame
 setTitle(title:string)    #sets title for window
 getWidth() : int   #returns current window width
 getHeight() : int  #returns current window height
+
+#JAVASCRIPT
+eval(code: string): string   # Executes JS code and returns result as string.
+createCallback(cb: JSCallback; jsEvent: cstring)  # Registers a callback that receives JS event data as JSON. (JSCallback type is: proc(arg: cstring){.cdecl.}  )
+createCallback(cb: JSCallbackVoid; jsEvent: cstring) # Registers a more performant callback thanks to no event data arguments (JSCallbackVoid type is: proc(){.cdecl.} )
+
 ```
 </details>
 

--- a/src/javascript.nim
+++ b/src/javascript.nim
@@ -1,6 +1,3 @@
-#region Javascript
-
-import json
 
 type
     JSCallback* = proc(arg: cstring) {.cdecl.}      # For JSON argument callbacks(string)
@@ -58,45 +55,34 @@ when defined(emscripten):
     proc kirpi_create_callback_void(cb: JSCallbackVoid, eventName: cstring): cint {.importc, nodecl.}
 
     # Eval Functions
-    proc emscripten_run_script_int(script: cstring): cint {.importc, header: "<emscripten/emscripten.h>".}
-    proc emscripten_run_script_double(script: cstring): cdouble {.importc, header: "<emscripten/emscripten.h>".}
-    proc emscripten_run_script_bool(script: cstring): cint {.importc, header: "<emscripten/emscripten.h>".}
     proc emscripten_run_script_string(script: cstring): cstring {.importc, header: "<emscripten/emscripten.h>".}
-    proc emscripten_run_script(script: cstring): void {.importc, header: "<emscripten/emscripten.h>".}
+    #---Maybe useful later
+    #proc emscripten_run_script_int(script: cstring): cint {.importc, header: "<emscripten/emscripten.h>".}
+    #proc emscripten_run_script_double(script: cstring): cdouble {.importc, header: "<emscripten/emscripten.h>".}
+    #proc emscripten_run_script_bool(script: cstring): cint {.importc, header: "<emscripten/emscripten.h>".}
+    #proc emscripten_run_script(script: cstring): void {.importc, header: "<emscripten/emscripten.h>".}
 
 proc cstring2String(cstr: cstring): string =
   if cstr == nil: ""
   else: $cstr
 
 # Json Returning Callback
-proc createCallback*(cb: JSCallback; jsEvent: cstring): cint =
+proc createCallback*(cb: JSCallback; jsEvent: cstring) =
     when defined(emscripten):
-        result = kirpi_create_callback(cb, jsEvent)
-    else: result = 0
+        discard kirpi_create_callback(cb, jsEvent)
+    else: discard
 
 # Void Callback
-proc createCallback*(cb: JSCallbackVoid; jsEvent: cstring): cint =
+proc createCallback*(cb: JSCallbackVoid; jsEvent: cstring) =
     when defined(emscripten):
-        result = kirpi_create_callback_void(cb, jsEvent)
-    else: result = 0
+        discard kirpi_create_callback_void(cb, jsEvent)
+    else: discard
 
 # generic eval
-proc eval(code: string): string =
+proc eval*(code: string): string =
   when defined(emscripten):
     result = emscripten_run_script_string(code.cstring).cstring2String()
   else:
     result = ""
 
-# test callback
-# 1. Senaryo: Veri lazım
-proc onDetailedClick(jsonArgs: cstring) {.cdecl.} =
-    echo "Detaylı veri geldi: ", $jsonArgs
 
-# 2. Senaryo: Sadece tıklandığını bilsem yeter
-proc onSimpleClick() {.cdecl.} =
-    echo "Sadece tıklandı, JSON ile vakit kaybetmedik."
-
-discard createCallback(onDetailedClick, "contextmenu") # Sağ tık, detaylı
-discard createCallback(onSimpleClick, "click")         # Sol tık, hızlı
-
-#endregion

--- a/src/kirpi.nim
+++ b/src/kirpi.nim
@@ -4,7 +4,7 @@ import tables
 import raylib as rl
 import rsc
 import hashes
-import bridge
+import javascript
 
 
 #Emscripten /Web Main Loop Fix Wrapper (We don't want to use Asyncify on the web targets)
@@ -205,4 +205,4 @@ proc run*(title:string,load: proc(), update: proc(dt:float), draw: proc(), confi
 export graphics except defaultFilter,shaders,fonts
 export inputs, window
 export sound 
-export bridge
+export javascript

--- a/tests/using_js.nim
+++ b/tests/using_js.nim
@@ -1,0 +1,32 @@
+import ../src/kirpi
+
+# tests
+proc onDetailedClick(jsonArgs: cstring) {.cdecl.} =
+    echo "Detailed Click Data: ", $jsonArgs
+
+
+proc onSimpleClick() {.cdecl.} =
+    echo "There's no data, it's just a callback."
+
+
+proc load() =
+    javascript.createCallback(onDetailedClick, "contextmenu") # Right Click, with Callback Data
+    javascript.createCallback(onSimpleClick, "click")         # Left Click, No Callback Data
+    
+
+proc update( dt:float) =
+    if isKeyPressed(KeyboardKey.Space):
+        discard javascript.eval("alert('Hello from Nim via JS eval!');")
+    
+
+proc draw() =
+    clear(White)
+    setColor(Black)
+    draw(newText("-Right Click anywhere to see detailed event data in console.",getDefaultFont()),50,100,32)
+    draw(newText("-Left Click anywhere to see a simple alert callback.",getDefaultFont()),50,150,32)
+    draw(newText("-Press SPACE to see JS eval in action.",getDefaultFont()),50,200,32)
+    
+
+    discard
+
+run("Using JS", load, update, draw)


### PR DESCRIPTION
This PR introduces `eval` and `createCallback` procedures to the API, enabling communication with JavaScript on web targets and allowing the creation of wrapper modules for various Web SDKs.

A simple example of its use.
``` Nim
#using_js.nim

import kirpi 

proc onDetailedClick(jsonArgs: cstring) {.cdecl.} =
    echo "Detailed Click Data: ", $jsonArgs


proc onSimpleClick() {.cdecl.} =
    echo "There's no data, it's just a callback."


proc load() =
    javascript.createCallback(onDetailedClick, "contextmenu") # Right Click, with Callback Data
    javascript.createCallback(onSimpleClick, "click")         # Left Click, No Callback Data
    

proc update( dt:float) =
    if isKeyPressed(KeyboardKey.Space):
        discard javascript.eval("alert('Hello from Nim via JS eval!');")
    

proc draw() =
    discard

run("Using JS", load, update, draw)

```