### PR TITLE
Add helper procedures to manage sprites in the SpriteBatch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -195,10 +195,16 @@ clear(color:Color)     #clears the screen with the specified color.
 getSizeWith(text:Text,fontSize:float,spacing:float=1.0) :tuple[x:float,y:float] # returns the text size using the specified font size and spacing.
 
 #SpriteBatch Methods 
-#adds an instance to SpriteBatch
+#adds an instance to SpriteBatch.It returns the index number of the sprite.
 add(spriteBatch: var SpriteBatch,x,y:float,r:float=0,sx:float=1,sy:float=1,ox:float=0,oy:float=0,kx:float=0,ky:float=0):int
-#adds an instance to SpriteBatch with Quad
+#adds an instance to SpriteBatch with Quad. It returns the index number of the sprite.
 add(spriteBatch: var SpriteBatch, quad:Quad, x,y:float,r:float=0,sx:float=1,sy:float=1,ox:float=0,oy:float=0,kx:float=0,ky:float=0):int 
+#Sets the transform of the sprite at the specified index.
+setSpriteTransform(spriteBatch:var SpriteBatch,spriteID:int,x:float,y:float,r:float=0,sx:float=1,sy:float=1,ox:float=0,oy:float=0,kx:float=0,ky:float=0)
+#Sets the quad of the sprite at the specified index.
+setSpriteQuad(spriteBatch:var SpriteBatch,spriteID:int,quad:Quad)
+#Returns the number of sprites in the sprite batch.
+getSpriteCount(spriteBatch:var SpriteBatch) : int
 
 #Shader Methods  
 setShader(shader:Shader) #  sets the specified shader for subsequent drawing operations. 

--- a/src/backends/naylib/graphics_end.nim
+++ b/src/backends/naylib/graphics_end.nim
@@ -71,6 +71,7 @@ proc setShaderTextureValue*(shaderID:Hash, uniformName:string, textureID:Hash)
 proc renderGeometry*(vertices:var seq[tuple[x,y,uvx,uvy:float]],indices:var seq[int],color:tuple[r,g,b,a:uint8],textureDataID:int=0)
 proc renderGeometry*(trianglePoints:var seq[tuple[x,y,uvx,uvy:float]],color:tuple[r,g,b,a:uint8],textureDataID:int=0)
 
+
 proc clearCanvas*(color:tuple[r,g,b,a:uint8]) 
     
 #endregion
@@ -356,6 +357,10 @@ proc renderGeometry*(trianglePoints:var seq[tuple[x,y,uvx,uvy:float]],color:tupl
     rlEnd()
     setTexture(0)
 
+
+
+
+#Clear canvas with a specified color 
 proc clearCanvas*(color:tuple[r,g,b,a:uint8]) =
     clearBackground( Color(r:color.r,g:color.g,b:color.b,a:color.a) )
   

--- a/src/graphics.nim
+++ b/src/graphics.nim
@@ -460,13 +460,28 @@ proc add*(spriteBatch: var SpriteBatch,x,y:float,r:float=0,sx:float=1,sy:float=1
 proc add*(spriteBatch: var SpriteBatch, quad:Quad, x,y:float,r:float=0,sx:float=1,sy:float=1,ox:float=0,oy:float=0,kx:float=0,ky:float=0):int =
   var t:Transform=newTransform(x,y,r,sx,sy,ox,oy,kx,ky)
   var q=quad
-  let id=spriteBatch.data.len
+  let index=spriteBatch.data.len
   spriteBatch.data.add( (q,t) )
   
-  result=id
+  result=index
 
 proc clear*(spriteBatch: var SpriteBatch) =
   spriteBatch.data.setLen(0)
+
+
+proc setSpriteTransform*(spriteBatch:var SpriteBatch,spriteID:int,x:float,y:float,r:float=0,sx:float=1,sy:float=1,ox:float=0,oy:float=0,kx:float=0,ky:float=0)=
+  var t:Transform=newTransform(x,y,r,sx,sy,ox,oy,kx,ky)
+  spriteBatch.data[spriteID][1]=t
+  
+proc setSpriteQuad*(spriteBatch:var SpriteBatch,spriteID:int,quad:Quad)=
+  spriteBatch.data[spriteID][0]=quad
+
+proc getSpriteCount*(spriteBatch:var SpriteBatch) : int =
+  return spriteBatch.data.len
+
+
+  
+  
   
 ### End of Sprite Batcher Methods ###
 

--- a/tests/using_spritebatch.nim
+++ b/tests/using_spritebatch.nim
@@ -11,6 +11,7 @@ type
     y:float
     beginY:float
     flip:bool # swim direction
+    spriteID:int
 
 
 var fishes:seq[Fish] # All fish instances stored here
@@ -29,7 +30,17 @@ proc reCreateFishes(count:int) =
     var nFish=Fish(x:rand(window.getWidth().float), y:rand(window.getWidth().float))
     nFish.beginY=nFish.y
     nFish.flip=if rand(5.int)==3 : true else : false
+    nFish.spriteID=spriteBatch.add(  # It returns an index; we capture it here just to demonstrate it.
+      nFish.x, # x position
+      nFish.y, # y position
+      0.0,  # rotation
+      1.0, # scale x
+      1.0, # scale y
+      fishTexture.width.float*0.5, # origin x 
+      fishTexture.height.float*0.5 # origin y
+    )
     fishes.add(nFish)
+    
 
 
 proc config(settings : var AppSettings) =
@@ -53,6 +64,8 @@ proc update( dt:float) =
     fishCount=max(0,fishCount-1000) 
     reCreateFishes(fishCount) # Rebuild batch with new count
 
+
+  let scale=0.2
   # Update fish motion 
   # Horizontal movement + sine wave
   for i in 0..<fishes.len: 
@@ -63,22 +76,13 @@ proc update( dt:float) =
     else : fishes[i].x += 0.5
 
     fishes[i].y = fishes[i].beginY + sin(getTime() + fishes[i].beginY)*16
+    let flipFactor:float = if fishes[i].flip : -1 else : 1
+    spriteBatch.setSpriteTransform(fishes[i].spriteID,fishes[i].x,fishes[i].y,0.0,flipFactor*scale,scale,fishTexture.width*0.5,fishTexture.height*0.5)
   
   # Refill batch with transforms
-  spriteBatch.clear()
-  let scale=0.2
-  for i in 0..<fishes.len :
-    let flipFactor:float = if fishes[i].flip : -1 else : 1
-    # Add fish sprite to the batch with flip + scale applied
-    let batchID=spriteBatch.add(  # It returns an ID; we capture it here just to demonstrate it.
-      fishes[i].x, # x position
-      fishes[i].y, # y position
-      0.0,  # rotation
-      flipFactor*scale, # scale x
-      scale, # scale y
-      fishTexture.width.float*0.5, # origin x 
-      fishTexture.height.float*0.5 # origin y
-    )
+  
+  
+    
 
 # Draw batch + UI
 proc draw() =


### PR DESCRIPTION
This PR adds the necessary procedures such as `setSpriteTransform`, `setSpriteQuad`, and `getSpriteCount`, which allow managing the sprites defined in a SpriteBatch.